### PR TITLE
Remove ExceptionAnalysis.Diagnostics package

### DIFF
--- a/src/HtmlGenerator/HtmlGenerator.csproj
+++ b/src/HtmlGenerator/HtmlGenerator.csproj
@@ -35,7 +35,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ExceptionAnalysis.Diagnostics" Version="1.0.0.39796" />
     <PackageReference Include="ManagedEsent" Version="2.0.0" />
     <PackageReference Include="Microsoft.Build" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(NuGetVersionMSBuild)" ExcludeAssets="runtime" />

--- a/src/HtmlGenerator/Utilities/FirstChanceExceptionHandler.cs
+++ b/src/HtmlGenerator/Utilities/FirstChanceExceptionHandler.cs
@@ -1,13 +1,13 @@
-﻿using System;
+﻿using Microsoft.SourceBrowser.Common;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Xml;
-using Microsoft.SourceBrowser.Common;
-using ExceptionAnalysis.Diagnostics;
-using System.Linq;
-using System.Reflection;
 
 namespace Microsoft.SourceBrowser.HtmlGenerator
 {
@@ -137,9 +137,9 @@ namespace Microsoft.SourceBrowser.HtmlGenerator
                         return;
                     }
 
-                    var trace = new TraceFactory().Manufacture(ex);
+                    var trace = new StackTrace( ex, fNeedFileInfo: true );
 
-                    if (trace.Select(f => f.Method.Module).Any(IgnoredModules.Contains))
+                    if (trace.GetFrames().Select(f => f.GetMethod().Module).Any(IgnoredModules.Contains))
                     {
                         return;
                     }


### PR DESCRIPTION
Only supports .NET Framework. Trivial replacement.